### PR TITLE
Verificação da String que já vem preenchida

### DIFF
--- a/aplicacao/contest/src/main/java/ufc/quixada/npi/contest/controller/EventoController.java
+++ b/aplicacao/contest/src/main/java/ufc/quixada/npi/contest/controller/EventoController.java
@@ -100,7 +100,7 @@ public class EventoController extends EventoGenericoController {
 		String url = request.getScheme() + "://" + request.getServerName() + ":" + request.getServerPort() + request.getContextPath();
 		
 		
-		if (organizador.getEmail() == null || organizador.getEmail().isEmpty()) {
+		if (organizador.getEmail() == null || organizador.getEmail().isEmpty() || organizador.getEmail().equalsIgnoreCase("Email do Organizador")) {
 			result.reject(ORGANIZADOR_ERROR, messageService.getMessage(ORGANIZADOR_VAZIO_ERROR));
 		}
 


### PR DESCRIPTION
Para evento, email do organizador é obrigatório, estava acontecendo do campo email de organizador estava preenchido de forma incorreta, caso nenhum email fosse fornecido, agora o preenchimento que vem do thymeleaf está sendo tratado. 